### PR TITLE
buf fix: fix nsp ,nsi mask

### DIFF
--- a/ofproto/tunnel.c
+++ b/ofproto/tunnel.c
@@ -391,9 +391,13 @@ tnl_xlate_init(const struct flow *base_flow, struct flow *flow,
         wc->masks.tunnel.ip_dst = OVS_BE32_MAX;
         wc->masks.tunnel.flags = (FLOW_TNL_F_DONT_FRAGMENT |
                                   FLOW_TNL_F_CSUM |
-                                  FLOW_TNL_F_KEY);
+                                  FLOW_TNL_F_KEY | 
+                                  FLOW_TNL_F_NSP |
+                                  FLOW_TNL_F_NSI);
         wc->masks.tunnel.ip_tos = UINT8_MAX;
         wc->masks.tunnel.ip_ttl = UINT8_MAX;
+        wc->masks.tunnel.nsp = OVS_BE32_MAX;
+		wc->masks.tunnel.nsi = UINT8_MAX;
 
         memset(&wc->masks.pkt_mark, 0xff, sizeof wc->masks.pkt_mark);
 

--- a/ofproto/tunnel.c
+++ b/ofproto/tunnel.c
@@ -397,7 +397,7 @@ tnl_xlate_init(const struct flow *base_flow, struct flow *flow,
         wc->masks.tunnel.ip_tos = UINT8_MAX;
         wc->masks.tunnel.ip_ttl = UINT8_MAX;
         wc->masks.tunnel.nsp = OVS_BE32_MAX;
-		wc->masks.tunnel.nsi = UINT8_MAX;
+	wc->masks.tunnel.nsi = UINT8_MAX;
 
         memset(&wc->masks.pkt_mark, 0xff, sizeof wc->masks.pkt_mark);
 


### PR DESCRIPTION
We should make the nsp,nsi full-mask.If not so, when a packet flow with nsp,nsi suddenly changed, it will still hit the wrong datapath flow in    kernel in stead of a flow miss. For example, a user configure two rule1: nsp=1,nsi=1,actions=output:1    rule2: nsp=2,actions=output:2
 when a packet with nsp=1,nsi=1 arrives, if megaflow enabled which is the defaults, the datapath flow will be like nsp=1/0x0,nsi=1/0x1,so if we suddenlly change the packet flow with nsp=2,nsi=2,it will still hit the flow because of the mask is 0. So, we must make the mask full "F."